### PR TITLE
Do not provide the test-helper feature

### DIFF
--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -96,8 +96,6 @@
   (defun ert-runner/run-tests-batch-and-exit (selector)
     (ert-run-tests-interactively selector)))
 
-(provide 'test-helper)
-
 ;; Local Variables:
 ;; indent-tabs-mode: nil
 ;; End:

--- a/test/zephir-mode-font-test.el
+++ b/test/zephir-mode-font-test.el
@@ -33,8 +33,6 @@
 
 ;;; Code:
 
-(require 'test-helper)
-
 
 ;;;; Utilities
 

--- a/test/zephir-mode-moving-test.el
+++ b/test/zephir-mode-moving-test.el
@@ -33,8 +33,6 @@
 
 ;;; Code:
 
-(require 'test-helper)
-
 
 ;;;; Utilities
 


### PR DESCRIPTION
"test-helper.el" isn't a library intended to be loaded with `require`.
Instead it is loaded with `load` by `ert-runner` itself.  Because of
that, it is confusing to provide a feature using `provide`.  It also
isn't possible to use `require` to load `test-helper` because that
might, depending on the order of `load-path` load the "test-helper.el"
of another package that used `ert-runner`.

This is also discussed at rejeep/ert-runner.el#38.